### PR TITLE
ci: Upgrade GitHub Actions to Node 22+ runtimes [sc-178410]

### DIFF
--- a/.github/workflows/call-create-release.yaml
+++ b/.github/workflows/call-create-release.yaml
@@ -30,7 +30,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout API repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: calyptia/core-operator-releases
           token: ${{ secrets.ci-pat }}
@@ -64,7 +64,7 @@ jobs:
           GH_TOKEN: ${{ secrets.ci-pat }}
 
       - name: Add, Commit, and Push Changes
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         with:
           message: Updated to $repository version ${{ inputs.release_tag }}
           push: true

--- a/.github/workflows/call-create-release.yaml
+++ b/.github/workflows/call-create-release.yaml
@@ -70,12 +70,12 @@ jobs:
           push: true
 
       - name: Create Tag and Release
-        uses: marvinpinto/action-automatic-releases@latest
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
-          repo_token: ${{ secrets.ci-pat }}
+          token: ${{ secrets.ci-pat }}
           files: |
             ${{ steps.fetch_artifacts.outputs.artifacts }}
-          title: Release ${{ inputs.release_tag }}
-          automatic_release_tag: ${{ inputs.release_tag }}
+          name: Release ${{ inputs.release_tag }}
+          tag_name: ${{ inputs.release_tag }}
           draft: false
           prerelease: false

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: PR - Actionlint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: |
           echo "::add-matcher::.github/actionlint-matcher.json"
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
@@ -19,6 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     name: PR - Markdownlint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run markdownlint
         uses: actionshub/markdownlint@v3.1.4


### PR DESCRIPTION
## Summary
- Upgrades all JS-based GitHub Actions from Node 20 (or older) to Node 22+ versions
- SHA-pins all upgraded action references for supply-chain security
- Replaces `marvinpinto/action-automatic-releases@latest` with `softprops/action-gh-release@v3.0.0` (original action stuck on Node 12)
- Addresses upcoming [Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

[sc-178410](https://app.shortcut.com/chronosphere/story/178410)

## Test plan
- [ ] CI passes on this branch
- [ ] Verify workflow behavior unchanged
- [ ] Verify release creation still works with softprops/action-gh-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)