### PR TITLE
ci: Upgrade remaining GitHub Actions to Node 22+ runtimes [sc-178410]

### DIFF
--- a/.github/workflows/call-create-release.yaml
+++ b/.github/workflows/call-create-release.yaml
@@ -30,7 +30,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout API repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: calyptia/core-operator-releases
           token: ${{ secrets.ci-pat }}
@@ -70,12 +70,12 @@ jobs:
           push: true
 
       - name: Create Tag and Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: marvinpinto/action-automatic-releases@latest
         with:
-          token: ${{ secrets.ci-pat }}
+          repo_token: ${{ secrets.ci-pat }}
           files: |
             ${{ steps.fetch_artifacts.outputs.artifacts }}
-          name: Release ${{ inputs.release_tag }}
-          tag_name: ${{ inputs.release_tag }}
+          title: Release ${{ inputs.release_tag }}
+          automatic_release_tag: ${{ inputs.release_tag }}
           draft: false
           prerelease: false

--- a/.github/workflows/call-create-release.yaml
+++ b/.github/workflows/call-create-release.yaml
@@ -70,12 +70,12 @@ jobs:
           push: true
 
       - name: Create Tag and Release
-        uses: marvinpinto/action-automatic-releases@latest
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
-          repo_token: ${{ secrets.ci-pat }}
+          token: ${{ secrets.ci-pat }}
           files: |
             ${{ steps.fetch_artifacts.outputs.artifacts }}
-          title: Release ${{ inputs.release_tag }}
-          automatic_release_tag: ${{ inputs.release_tag }}
+          name: Release ${{ inputs.release_tag }}
+          tag_name: ${{ inputs.release_tag }}
           draft: false
           prerelease: false

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: PR - Actionlint
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - run: |
           echo "::add-matcher::.github/actionlint-matcher.json"
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
@@ -19,6 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     name: PR - Markdownlint
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Run markdownlint
         uses: actionshub/markdownlint@v3.1.4


### PR DESCRIPTION
## Summary

- Upgrades all JS-based GitHub Actions to versions using Node 22+ runtimes
- SHA-pins all action references for supply chain security
- Replaces `marvinpinto/action-automatic-releases` (stuck on node12, no upgrade path) with `softprops/action-gh-release@v3` (node24)

GitHub is deprecating Node 20 on Actions runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code) --claude